### PR TITLE
Update outdated JavaPingResponse type

### DIFF
--- a/types/lib/java.d.ts
+++ b/types/lib/java.d.ts
@@ -1,5 +1,20 @@
 import { PingOptions } from "./bedrock";
 
+/**
+ * JSON format chat component used for description field.
+ * @see https://wiki.vg/Chat
+ */
+export type ChatComponent = {
+    text: string;
+    bold?: boolean;
+    italic?: boolean;
+    underlined?: boolean;
+    strikethrough?: boolean;
+    obfuscated?: boolean;
+    color?: string;
+    extra?: ChatComponent[];
+};
+
 export type SampleProp = {
     name: string,
     id: string;
@@ -17,10 +32,12 @@ export type JavaPingResponse = {
     players: {
         max: number;
         online: number;
-        sample: SampleProp[];
+        sample?: SampleProp[];
     };
-    description: string;
-    favicon: string;
+    description: string | ChatComponent;
+    favicon?: string;
+    enforcesSecureChat?: boolean;
+    previewsChat?: boolean;
 };
 
 /**


### PR DESCRIPTION
Thank you for the great library ❤️ 

I've made some updates to changes in https://wiki.vg/Server_List_Ping#Response.

## description
```json
    "description": {
        "text": "Hello world"
    },
```

> The description field is a [Chat](https://wiki.vg/Chat) object. Note that the Notchian server has no way of providing actual chat component data; instead section sign-based codes are embedded within the text of the object. However, third-party servers such as Spigot and Paper will return full components, so make sure you can handle both.

I have made these adjustments to accommodate the possibility of returning JSON-formatted chat components instead of section signs. For more information about chat components, please refer to https://wiki.vg/Chat (some servers may return click events and hover events, but these have no meaning as an MOTD, so they are ignored).

## favicon
> The favicon field is optional.

## players.sample
> The sample field may be missing if the server has no online players.

## enforcesSecureChat, previewsChat
```json
    "enforcesSecureChat": true,
    "previewsChat": true
```
I added these as optional fields since they may or may not be included in the response.

Thank you 😉 