### PR TITLE
fix(types): Change options to optional

### DIFF
--- a/types/lib/bedrock.d.ts
+++ b/types/lib/bedrock.d.ts
@@ -3,8 +3,8 @@
  * @param timeout The read/write socket timeout.
  */
 export type BedrockPingOptions = {
-    port: number,
-    timeout: number;
+    port?: number | undefined,
+    timeout?: number | undefined;
 };
 
 export type BedrockPingResponse = {
@@ -26,6 +26,7 @@ export type BedrockPingResponse = {
  * The optional `options` argument can be an object with a `ping` (default is `19132`) or/and `timeout` (default is `5000`) property.
  * 
  * @param host The Bedrock server address.
+ * @param options The configuration for pinging Minecraft Bedrock server.
  * 
  * ```js
  * import { pingBedrock } from '@minescope/mineping';

--- a/types/lib/java.d.ts
+++ b/types/lib/java.d.ts
@@ -4,9 +4,9 @@
  * @param protocolVersion The protocol version.
  */
 export type JavaPingOptions = {
-    port: number,
-    timeout: number,
-    protocolVersion: number;
+    port?: number | undefined,
+    timeout?: number | undefined,
+    protocolVersion?: number | undefined;
 };
 
 /**


### PR DESCRIPTION
All options are optional in the JS code, but are required in the TS type definition.